### PR TITLE
spapadop/plt-862-fix-namespace-usage-in-rendered-manifest-files

### DIFF
--- a/internal/templates/renderer_test.go
+++ b/internal/templates/renderer_test.go
@@ -26,6 +26,7 @@ func TestRenderTemplate(t *testing.T) {
 			},
 			UID:   2000,
 			Image: "ubuntu:22.04",
+			Namespace: "devenv-test",
 			Packages: config.PackageConfig{
 				Python: []string{"numpy", "pandas"},
 				APT:    []string{"vim", "curl"},
@@ -57,7 +58,7 @@ func TestRenderTemplate(t *testing.T) {
 		},
 	}
 
-	templates := []string{"statefulset", "service", "env-vars", "startup-scripts"}
+	templates := []string{"statefulset", "service", "env-vars", "startup-scripts", "ingress"}
 
 	for _, templateName := range templates {
 		t.Run(templateName, func(t *testing.T) {
@@ -109,6 +110,7 @@ func TestRenderAll(t *testing.T) {
 		Name: "minimal",
 		BaseConfig: config.BaseConfig{
 			SSHPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7... minimal@example.com",
+			Namespace:   "devenv-test",
 		},
 		SSHPort: 30002,
 	}
@@ -121,7 +123,7 @@ func TestRenderAll(t *testing.T) {
 	require.NoError(t, err, "RenderAll should not return error")
 
 	// Verify all expected files were created
-	expectedFiles := []string{"statefulset.yaml", "service.yaml", "env-vars.yaml", "startup-scripts.yaml"}
+	expectedFiles := []string{"statefulset.yaml", "service.yaml", "env-vars.yaml", "startup-scripts.yaml", "ingress.yaml"}
 
 	for _, filename := range expectedFiles {
 		filePath := filepath.Join(tempDir, filename)

--- a/internal/templates/template_files/dev/manifests/env-vars.tmpl
+++ b/internal/templates/template_files/dev/manifests/env-vars.tmpl
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: env-vars-{{.Name}}
+  namespace: {{.Namespace}}
   labels:
     app: devenv-{{.Name}}
 data:

--- a/internal/templates/template_files/dev/manifests/ingress.tmpl
+++ b/internal/templates/template_files/dev/manifests/ingress.tmpl
@@ -2,6 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: devenv-ingress-{{.Name}}
+  namespace: {{.Namespace}}
   annotations:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     cert-manager.io/cluster-issuer: "letsencrypt"

--- a/internal/templates/template_files/dev/manifests/service.tmpl
+++ b/internal/templates/template_files/dev/manifests/service.tmpl
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: devenv-ssh-{{.Name}}
+  namespace: {{.Namespace}}
   labels:
     app: devenv-{{.Name}}
     service: ssh
@@ -21,6 +22,7 @@ apiVersion: v1
 kind: Service  
 metadata:
   name: devenv-http-{{.Name}}
+  namespace: {{.Namespace}}
   labels:
     app: devenv-{{.Name}}
     service: http

--- a/internal/templates/template_files/dev/manifests/startup-scripts.tmpl
+++ b/internal/templates/template_files/dev/manifests/startup-scripts.tmpl
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: startup-scripts-{{.Name}}
+  namespace: {{.Namespace}}
   labels:
     app: devenv-{{.Name}}
 data:

--- a/internal/templates/template_files/dev/manifests/statefulset.tmpl
+++ b/internal/templates/template_files/dev/manifests/statefulset.tmpl
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: devenv-{{.Name}}
+  namespace: {{.Namespace}}
   labels:
     app: devenv-{{.Name}}
     component: devenv

--- a/internal/templates/testdata/golden/env-vars.yaml
+++ b/internal/templates/testdata/golden/env-vars.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: env-vars-testuser
+  namespace: devenv-test
   labels:
     app: devenv-testuser
 data:

--- a/internal/templates/testdata/golden/ingress.yaml
+++ b/internal/templates/testdata/golden/ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: devenv-ingress-testuser
+  namespace: devenv-test
+  annotations:
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+    
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: testuser.
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: devenv-http-testuser
+                port:
+                  name: http
+  tls:
+    - hosts:
+        - "*."
+      secretName: http-testuser-tls

--- a/internal/templates/testdata/golden/service.yaml
+++ b/internal/templates/testdata/golden/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: devenv-ssh-testuser
+  namespace: devenv-test
   labels:
     app: devenv-testuser
     service: ssh
@@ -20,6 +21,7 @@ apiVersion: v1
 kind: Service  
 metadata:
   name: devenv-http-testuser
+  namespace: devenv-test
   labels:
     app: devenv-testuser
     service: http

--- a/internal/templates/testdata/golden/startup-scripts.yaml
+++ b/internal/templates/testdata/golden/startup-scripts.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: startup-scripts-testuser
+  namespace: devenv-test
   labels:
     app: devenv-testuser
 data:

--- a/internal/templates/testdata/golden/statefulset.yaml
+++ b/internal/templates/testdata/golden/statefulset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: devenv-testuser
+  namespace: devenv-test
   labels:
     app: devenv-testuser
     component: devenv


### PR DESCRIPTION
## Summary
- This PR is stacked on top of #25. 
  - Will rebase after # 25 merges.

This PR fixes namespace propagation in rendered Kubernetes manifests.

Previously, setting `namespace` in config rendered a `Namespace` resource, but several namespaced resources did not include `metadata.namespace`, so they did not explicitly target the configured namespace.

## What changed
- Added `metadata.namespace: {{.Namespace}}` to all namespaced dev manifest templates:
  - `statefulset`
  - `service` (SSH + HTTP service docs in same template)
  - `env-vars` configmap
  - `startup-scripts` configmap
  - `ingress`
- Updated template tests to include `ingress` in golden coverage.
- Regenerated golden files, including new `internal/templates/testdata/golden/ingress.yaml`.

## Why
Ensures all rendered namespaced resources are deployed into the configured namespace, matching the completion criteria for this issue.

## Validation
- Ran:
```bash
go test -v -race -covermode=atomic -coverprofile=./coverage.out ./...
```
Result: all tests passed.
- manifests target correct namespace when applied
## Notes
- Cluster-scoped `Namespace` behavior is unchanged.
- This PR is stacked on top of #25.
- Fixes PLT-862