### PR TITLE
Spapadop/plt 849 statefulset servicename does not match any generated service

### DIFF
--- a/internal/templates/template_files/dev/manifests/service.tmpl
+++ b/internal/templates/template_files/dev/manifests/service.tmpl
@@ -1,6 +1,24 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: devenv-{{.Name}}
+  namespace: {{.Namespace}}
+  labels:
+    app: devenv-{{.Name}}
+    service: governing
+spec:
+  clusterIP: None
+  selector:
+    app: devenv-{{.Name}}
+  ports:
+  - name: ssh
+    port: 22
+    targetPort: 22
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
   name: devenv-ssh-{{.Name}}
   namespace: {{.Namespace}}
   labels:

--- a/internal/templates/testdata/golden/service.yaml
+++ b/internal/templates/testdata/golden/service.yaml
@@ -1,6 +1,24 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: devenv-testuser
+  namespace: devenv-test
+  labels:
+    app: devenv-testuser
+    service: governing
+spec:
+  clusterIP: None
+  selector:
+    app: devenv-testuser
+  ports:
+  - name: ssh
+    port: 22
+    targetPort: 22
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
   name: devenv-ssh-testuser
   namespace: devenv-test
   labels:


### PR DESCRIPTION
**Summary**
This PR is stacked on #26. It should be rebased after #26 is merged

This PR fixes a manifest mismatch where `StatefulSet.spec.serviceName` referenced `devenv-{{.Name}}` but no Service with that name was generated.

Changes:
- Added `devenv-{{.Name}}` headless Service (`clusterIP: None`) in `service.tmpl` as the StatefulSet governing service.
- Kept existing `devenv-ssh-{{.Name}}` NodePort Service unchanged.
- Kept optional `devenv-http-{{.Name}}` Service and ingress wiring unchanged.
- Updated service golden output and regenerated sample manifests.

**Why**
StatefulSets are expected to reference a governing Service (typically headless) for stable pod network identity. This removes the structural mismatch and ensures valid StatefulSet/Service topology.

**Validation**
- `go test ./internal/templates -update-golden`
- `go run ./cmd/devenv generate stelios --config-dir ./developers --output ./build`
- `go test -v -race -covermode=atomic -coverprofile=./coverage.out ./...`
- Validated on the atlab-devenv cluster (stelios) that StatefulSet/service topology is correct (matching serviceName, headless governing service, expected EndpointSlice, unchanged SSH NodePort, and correct HTTP ingress backend), and all checks passed.