### PR TITLE
Harden tag-triggered release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: Release
 on:
   push:
     tags:
-      - "v*" # Trigger on version tags like v0.1.0, v1.2.3
+      - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: write # Required for creating releases
@@ -11,85 +12,44 @@ permissions:
 jobs:
   test:
     name: Run Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.25"
-
-      - name: Run tests
-        run: go test -v ./...
+    uses: ./.github/workflows/run-test.yml
+    secrets: inherit
 
   release:
     name: Build and Release
-    needs: test # Only run if tests pass
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
 
-      - name: Build binaries for all platforms
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build release binaries
+        run: task build:dist
+
+      # Integration-tested platform: linux/amd64 runs natively in this CI environment.
+      # All other platforms (linux/arm64, darwin/amd64, darwin/arm64, windows/amd64)
+      # are cross-compiled only — binaries are published but not executed in CI.
+      - name: Validate linux/amd64 binary
         run: |
-          # Get version from tag (GitHub sets GITHUB_REF to refs/tags/v0.1.0)
-          VERSION=${GITHUB_REF#refs/tags/}
-          COMMIT=$(git rev-parse --short HEAD)
-          BUILD_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-          GO_VERSION=$(go version | awk '{print $3}')
-
-          echo "Building version: ${VERSION}"
-
-          # Build flags
-          LDFLAGS="-X main.version=${VERSION} -X main.gitCommit=${COMMIT} -X main.buildTime=${BUILD_TIME} -X main.goVersion=${GO_VERSION} -w -s"
-
-          # Create output directory
-          mkdir -p dist
-
-          # Linux amd64
-          echo "Building Linux amd64..."
-          GOOS=linux GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o dist/devenv-linux-amd64 ./cmd/devenv
-
-          # Linux arm64
-          echo "Building Linux arm64..."
-          GOOS=linux GOARCH=arm64 go build -ldflags="${LDFLAGS}" -o dist/devenv-linux-arm64 ./cmd/devenv
-
-          # macOS amd64 (Intel)
-          echo "Building macOS amd64..."
-          GOOS=darwin GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o dist/devenv-darwin-amd64 ./cmd/devenv
-
-          # macOS arm64 (Apple Silicon)
-          echo "Building macOS arm64..."
-          GOOS=darwin GOARCH=arm64 go build -ldflags="${LDFLAGS}" -o dist/devenv-darwin-arm64 ./cmd/devenv
-
-          # Windows amd64
-          echo "Building Windows amd64..."
-          GOOS=windows GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o dist/devenv-windows-amd64.exe ./cmd/devenv
-
-          echo "✅ All binaries built successfully"
-          ls -lh dist/
-
-      - name: Generate checksums
-        run: |
-          cd dist
-          sha256sum * > checksums.txt
+          VERSION=$(./scripts/get-version.sh)
+          ./dist/devenv_${VERSION}_linux_amd64 version
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            dist/devenv-linux-amd64
-            dist/devenv-linux-arm64
-            dist/devenv-darwin-amd64
-            dist/devenv-darwin-arm64
-            dist/devenv-windows-amd64.exe
+            dist/devenv_*
             dist/checksums.txt
           generate_release_notes: true
           draft: false

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -8,6 +8,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  workflow_call:
 
 jobs:
   build:
@@ -18,13 +19,19 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version-file: go.mod
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         run: go build -v ./...
 
       - name: Test
-        run: go test -v -race -covermode=atomic -coverprofile=./coverage.out ./...
+        run: task test:ci
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,138 +4,109 @@ vars:
   BINARY_NAME: devenv
   SOURCE_DIR: cmd/devenv
   BUILD_DIR: ./bin
+  DIST_DIR: ./dist
   MANIFEST_BUILD_DIR: ./build
+  VERSION:
+    sh: ./scripts/get-version.sh
+  COMMIT:
+    sh: git rev-parse --short HEAD 2>/dev/null || echo "unknown"
+  BUILD_TIME:
+    sh: date -u +'%Y-%m-%dT%H:%M:%SZ'
+  GO_VERSION:
+    sh: go version | awk '{print $3}'
+  LDFLAGS: "-X main.version={{.VERSION}} -X main.gitCommit={{.COMMIT}} -X main.buildTime={{.BUILD_TIME}} -X main.goVersion={{.GO_VERSION}} -w -s"
 
 
 
 tasks:
   build:
     desc: Build devenv binary with version info
-    env:
-      VERSION: 
-        sh: ./scripts/get-version.sh
     cmds:
-      - |
-        COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-        BUILD_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-        GO_VERSION=$(go version | awk '{print $3}')
-        
-        LDFLAGS="-X main.version=${VERSION} -X main.gitCommit=${COMMIT} -X main.buildTime=${BUILD_TIME} -X main.goVersion=${GO_VERSION}"
-        
-        echo "Building {{.BUILD_DIR}}/{{.BINARY_NAME}}..."
-        echo "  Version: ${VERSION}"
-
-        go build -ldflags="${LDFLAGS}" -o {{.BUILD_DIR}}/{{.BINARY_NAME}} ./{{.SOURCE_DIR}}
-        echo "✅ Build complete!"
+      - mkdir -p {{.BUILD_DIR}}
+      - go build -ldflags="{{.LDFLAGS}}" -o {{.BUILD_DIR}}/{{.BINARY_NAME}} ./{{.SOURCE_DIR}}
+      - echo "✅ Build complete ({{.VERSION}})"
 
   build:release:
     desc: Build optimized release binary
-    env:
-      VERSION: 
-        sh: ./scripts/get-version.sh
     cmds:
-      - |
-        COMMIT=$(git rev-parse --short HEAD)
-        BUILD_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-        GO_VERSION=$(go version | awk '{print $3}')
-        LDFLAGS="-X main.version=${VERSION} -X main.gitCommit=${COMMIT} -X main.buildTime=${BUILD_TIME} -X main.goVersion=${GO_VERSION} -w -s"
-        
-        mkdir -p {{.BUILD_DIR}}
-        go build -ldflags="${LDFLAGS}" -o {{.BUILD_DIR}}/{{.BINARY_NAME}} ./{{.SOURCE_DIR}}
-        echo "✅ Release binary: {{.BUILD_DIR}}/{{.BINARY_NAME}}"
+      - mkdir -p {{.BUILD_DIR}}
+      - go build -ldflags="{{.LDFLAGS}}" -o {{.BUILD_DIR}}/{{.BINARY_NAME}} ./{{.SOURCE_DIR}}
+      - echo "✅ Release binary {{.BUILD_DIR}}/{{.BINARY_NAME}}"
 
   build:all:
     desc: Build binaries for all platforms
     cmds:
       - task: build:linux
-      - task: build:darwin-amd64  
+      - task: build:linux-arm64
+      - task: build:darwin-amd64
       - task: build:darwin-arm64
       - task: build:windows
 
   build:linux:
-    env:
-      VERSION: 
-        sh: ./scripts/get-version.sh
     cmds:
-      - |
-        COMMIT=$(git rev-parse --short HEAD)
-        BUILD_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-        GO_VERSION=$(go version | awk '{print $3}')
-        LDFLAGS="-X main.version=${VERSION} -X main.gitCommit=${COMMIT} -X main.buildTime=${BUILD_TIME} -X main.goVersion=${GO_VERSION} -w -s"
-        
-        mkdir -p {{.BUILD_DIR}}
-        GOOS=linux GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o {{.BUILD_DIR}}/{{.BINARY_NAME}}-linux-amd64 ./{{.SOURCE_DIR}}
-        echo "✅ {{.BUILD_DIR}}/{{.BINARY_NAME}}-linux-amd64"
+      - mkdir -p {{.BUILD_DIR}}
+      - GOOS=linux GOARCH=amd64 go build -ldflags="{{.LDFLAGS}}" -o {{.BUILD_DIR}}/{{.BINARY_NAME}}-linux-amd64 ./{{.SOURCE_DIR}}
+      - echo "✅ {{.BUILD_DIR}}/{{.BINARY_NAME}}-linux-amd64"
+
+  build:linux-arm64:
+    cmds:
+      - mkdir -p {{.BUILD_DIR}}
+      - GOOS=linux GOARCH=arm64 go build -ldflags="{{.LDFLAGS}}" -o {{.BUILD_DIR}}/{{.BINARY_NAME}}-linux-arm64 ./{{.SOURCE_DIR}}
+      - echo "✅ {{.BUILD_DIR}}/{{.BINARY_NAME}}-linux-arm64"
 
   build:darwin-amd64:
-    env:
-      VERSION: 
-        sh: ./scripts/get-version.sh
     cmds:
-      - |
-        COMMIT=$(git rev-parse --short HEAD)
-        BUILD_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-        GO_VERSION=$(go version | awk '{print $3}')
-        LDFLAGS="-X main.version=${VERSION} -X main.gitCommit=${COMMIT} -X main.buildTime=${BUILD_TIME} -X main.goVersion=${GO_VERSION} -w -s"
-        
-        mkdir -p {{.BUILD_DIR}}
-        GOOS=darwin GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o {{.BUILD_DIR}}/{{.BINARY_NAME}}-darwin-amd64 ./{{.SOURCE_DIR}}
-        echo "✅ {{.BUILD_DIR}}/{{.BINARY_NAME}}-darwin-amd64"
+      - mkdir -p {{.BUILD_DIR}}
+      - GOOS=darwin GOARCH=amd64 go build -ldflags="{{.LDFLAGS}}" -o {{.BUILD_DIR}}/{{.BINARY_NAME}}-darwin-amd64 ./{{.SOURCE_DIR}}
+      - echo "✅ {{.BUILD_DIR}}/{{.BINARY_NAME}}-darwin-amd64"
 
   build:darwin-arm64:
-    env:
-      VERSION: 
-        sh: ./scripts/get-version.sh
     cmds:
-      - |
-        COMMIT=$(git rev-parse --short HEAD)
-        BUILD_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-        GO_VERSION=$(go version | awk '{print $3}')
-        LDFLAGS="-X main.version=${VERSION} -X main.gitCommit=${COMMIT} -X main.buildTime=${BUILD_TIME} -X main.goVersion=${GO_VERSION} -w -s"
-        
-        mkdir -p {{.BUILD_DIR}}
-        GOOS=darwin GOARCH=arm64 go build -ldflags="${LDFLAGS}" -o {{.BUILD_DIR}}/{{.BINARY_NAME}}-darwin-arm64 ./{{.SOURCE_DIR}}
-        echo "✅ {{.BUILD_DIR}}/{{.BINARY_NAME}}-darwin-arm64"
+      - mkdir -p {{.BUILD_DIR}}
+      - GOOS=darwin GOARCH=arm64 go build -ldflags="{{.LDFLAGS}}" -o {{.BUILD_DIR}}/{{.BINARY_NAME}}-darwin-arm64 ./{{.SOURCE_DIR}}
+      - echo "✅ {{.BUILD_DIR}}/{{.BINARY_NAME}}-darwin-arm64"
 
   build:windows:
-    env:
-      VERSION: 
-        sh: ./scripts/get-version.sh
     cmds:
-      - |
-        COMMIT=$(git rev-parse --short HEAD)
-        BUILD_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-        GO_VERSION=$(go version | awk '{print $3}')
-        LDFLAGS="-X main.version=${VERSION} -X main.gitCommit=${COMMIT} -X main.buildTime=${BUILD_TIME} -X main.goVersion=${GO_VERSION} -w -s"
-        
-        mkdir -p {{.BUILD_DIR}}
-        GOOS=windows GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o {{.BUILD_DIR}}/{{.BINARY_NAME}}-windows-amd64.exe ./{{.SOURCE_DIR}}
-        echo "✅ {{.BUILD_DIR}}/{{.BINARY_NAME}}-windows-amd64.exe"
+      - mkdir -p {{.BUILD_DIR}}
+      - GOOS=windows GOARCH=amd64 go build -ldflags="{{.LDFLAGS}}" -o {{.BUILD_DIR}}/{{.BINARY_NAME}}-windows-amd64.exe ./{{.SOURCE_DIR}}
+      - echo "✅ {{.BUILD_DIR}}/{{.BINARY_NAME}}-windows-amd64.exe"
 
-  
+  build:dist:
+    desc: Build all platform release binaries into dist/ with version in filename (used by CI)
+    cmds:
+      - mkdir -p {{.DIST_DIR}}
+      - GOOS=linux   GOARCH=amd64 go build -ldflags="{{.LDFLAGS}}" -o {{.DIST_DIR}}/{{.BINARY_NAME}}_{{.VERSION}}_linux_amd64     ./{{.SOURCE_DIR}}
+      - GOOS=linux   GOARCH=arm64 go build -ldflags="{{.LDFLAGS}}" -o {{.DIST_DIR}}/{{.BINARY_NAME}}_{{.VERSION}}_linux_arm64     ./{{.SOURCE_DIR}}
+      - GOOS=darwin  GOARCH=amd64 go build -ldflags="{{.LDFLAGS}}" -o {{.DIST_DIR}}/{{.BINARY_NAME}}_{{.VERSION}}_darwin_amd64    ./{{.SOURCE_DIR}}
+      - GOOS=darwin  GOARCH=arm64 go build -ldflags="{{.LDFLAGS}}" -o {{.DIST_DIR}}/{{.BINARY_NAME}}_{{.VERSION}}_darwin_arm64    ./{{.SOURCE_DIR}}
+      - GOOS=windows GOARCH=amd64 go build -ldflags="{{.LDFLAGS}}" -o {{.DIST_DIR}}/{{.BINARY_NAME}}_{{.VERSION}}_windows_amd64.exe ./{{.SOURCE_DIR}}
+      - cd {{.DIST_DIR}} && sha256sum * > checksums.txt
+      - echo "✅ dist/ ready ({{.VERSION}})"
+
   test:
     desc: Run tests
     cmds:
-      - go test ./... {{.CLI_ARGS}}
-  
+      - go test -race ./... {{.CLI_ARGS}}
+
+  test:ci:
+    desc: Run tests with race detector and coverage (used by CI)
+    cmds:
+      - go test -v -race -covermode=atomic -coverprofile=./coverage.out ./...
+
   clean:
     desc: Clean build artifacts
     cmds:
       - go clean
-      - rm -rf {{.BUILD_DIR}}
-      - rm -rf {{.MANIFEST_BUILD_DIR}}
+      - rm -rf {{.BUILD_DIR}} {{.DIST_DIR}} {{.MANIFEST_BUILD_DIR}}
       - echo "✅ Cleaned"
 
   update-golden:
     desc: Update golden files for tests
     cmds:
-      - go test ./... -- -update-golden {{.CLI_ARGS}} 
+      - go test ./... -- -update-golden {{.CLI_ARGS}}
 
   doc:
     desc: Launch pkgsite documentation server
     cmds:
       - pkgsite -open
-
-
-  
-

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -81,7 +81,7 @@ tasks:
       - GOOS=darwin  GOARCH=amd64 go build -ldflags="{{.LDFLAGS}}" -o {{.DIST_DIR}}/{{.BINARY_NAME}}_{{.VERSION}}_darwin_amd64    ./{{.SOURCE_DIR}}
       - GOOS=darwin  GOARCH=arm64 go build -ldflags="{{.LDFLAGS}}" -o {{.DIST_DIR}}/{{.BINARY_NAME}}_{{.VERSION}}_darwin_arm64    ./{{.SOURCE_DIR}}
       - GOOS=windows GOARCH=amd64 go build -ldflags="{{.LDFLAGS}}" -o {{.DIST_DIR}}/{{.BINARY_NAME}}_{{.VERSION}}_windows_amd64.exe ./{{.SOURCE_DIR}}
-      - cd {{.DIST_DIR}} && sha256sum * > checksums.txt
+      - cd {{.DIST_DIR}} && sha256sum $(ls | grep -v checksums.txt) > checksums.txt
       - echo "✅ dist/ ready ({{.VERSION}})"
 
   test:


### PR DESCRIPTION
## Summary

The existing release workflow was a prototype — it had a hardcoded Go version that doesn't exist (`1.25`), duplicated all build logic already owned by Taskfile, had no manual dispatch trigger, no smoke test, and no distinction between tested and untested platforms. This PR hardens the workflow to be intentional, maintainable, and the default release path.

## Changes

**`.github/workflows/release.yml`**
- Add `workflow_dispatch` trigger for manual releases
- Use `go-version-file: go.mod` as source of truth for Go version (fixes incorrect hardcoded `"1.25"`)
- Delegate test job to `run-test.yml` as a reusable workflow via `workflow_call`
- Replace 40-line inline build block with `task build:dist`
- Add `devenv --version` smoke test after build
- Add comment distinguishing integration-tested (linux/amd64) vs cross-compiled platforms
- Use versioned artifact naming (`devenv_{version}_{os}_{arch}`) with glob upload

**`.github/workflows/run-test.yml`**
- Add `workflow_call` trigger so it can be called by `release.yml`
- Use `go-version-file: go.mod` (fixes hardcoded `"1.24"`)
- Replace inline `go test` invocation with `task test:ci`

**`Taskfile.yml`**
- Promote `VERSION`, `COMMIT`, `BUILD_TIME`, `GO_VERSION`, `LDFLAGS` to global vars — eliminates 6x duplication across build tasks
- Add missing `build:linux-arm64` task; include in `build:all`
- Add `build:dist` — builds all 5 platforms into `dist/` with version-in-filename naming and checksums (used by CI)
- Add `test:ci` with full coverage flags; `test` now runs with `-race`
- `clean` now removes `dist/`

## Testing

- All tests pass locally via `task test:ci`
- `task build:dist` produces correct versioned artifacts with valid checksums
- Full end-to-end release tested via tag push — all 5 platform binaries published, version string verified (`devenv version v0.0.1-test`), checksums validated

## Notes

- When `workflow_dispatch` is triggered without a tag the `Create Release` step will fail — this is expected and acceptable; the trigger is useful for validating the build pipeline without publishing
- The test job in the Actions UI appears as `Run Tests / build` due to the reusable workflow job naming — this is expected behavior

Closes PLT-864